### PR TITLE
Release v1.1.0

### DIFF
--- a/XLCELL-PICKER.py
+++ b/XLCELL-PICKER.py
@@ -3,6 +3,7 @@ import glob
 import openpyxl
 import csv
 import pandas as pd
+import numpy
 import os
 import datetime
 import hashlib
@@ -80,6 +81,8 @@ def action_select():
     #------------------------------#
     # 空のデータフレームを作成（ハッシュ値も列として入れたいところ）
     df = pd.DataFrame(columns=["ファイル名", "SHA1ハッシュ値"] + dfncolumns)
+    # 空のリストを作成（下の繰り返し処理で指定シートない場合に当該Excelファイル名を格納）
+    List_nosheetxl = []
 
     # GUIで指定したExcel格納フォルダpaths内（*.xlsxのリスト）からに順にExcelを開き、カラムに対応する値を取得して追加していく
     for i, file_path in enumerate(paths):# file_path変数にファイルパスが1つずつ入る
@@ -108,7 +111,9 @@ def action_select():
         #対象シートが存在しなければその旨ポップアップ表示
         if sheet_exists == False:#「if not sheet_exists:」と同義
             print(f'指定されたシート「{tgtsheetname}」が存在しません')
-            messagebox.showerror('エラー', f'ファイル「{os.path.splitext(os.path.basename(file_path))[0]}」\n内に、定義ファイルで指定したシートがありません')
+            List_nosheetxl.append(os.path.splitext(os.path.basename(file_path))[0])
+            continue
+            # messagebox.showerror('エラー', f'ファイル「{os.path.splitext(os.path.basename(file_path))[0]}」\n内に、定義ファイルで指定したシートがありません')
         
         #カラム名のリストdfncolumnsと当該カラム名対応するセル番地リストdfncell_addressesを
         # zip関数で複数のリストの要素を同時に取得する（変数■,●in ■list,●listの対応順）
@@ -151,6 +156,11 @@ def action_select():
         df.to_csv(outputfld + f'\{outputfname}_{dt}_quotingON.csv', encoding="shift-jis", quoting=csv.QUOTE_ALL)
     print("処理完了")
     messagebox.showinfo('メッセージ', '出力完了しました')
+    #該当シートなしのExcelファイルがある場合だけ、該当ファイル名の一覧.csvを出力＋メッセージ表示
+    if len(List_nosheetxl) > 0 :
+        #該当シートなしのExcelファイル名のリストをGUI指定したoutputディレクトリに出力
+        numpy.savetxt(f'{outputfld}\該当シートなしのファイル一覧.csv', List_nosheetxl, fmt='%s', delimiter=',')
+        messagebox.showinfo('メッセージ', '定義ファイル指定シートがないExcelがあります。\n同時出力した一覧ファイルを確認ください。')
 
 #=================================#
 #GUIの定義

--- a/XLCELL-PICKER.py
+++ b/XLCELL-PICKER.py
@@ -167,7 +167,7 @@ def action_select():
 #=================================#
 root = tk.Tk()
 root.geometry("780x210+100+200")#画面サイズ＋左から100px上から200pxの位置にウィンドウ表示
-root.title("XLCELL-PICKER Ver.1.0.0")
+root.title("XLCELL-PICKER v1.1.0")
 #Excel格納フォルダには不要なものは入れないでのメッセージラベル作成
 msg1_label = tk.Label(text="Excel格納フォルダには対象のExcel以外は入れないでください。∵シート名で定義しているため")
 msg1_label.place(x=10, y=10)


### PR DESCRIPTION
# 定義ファイルでの指定シートに該当しない場合の処理追加
## 背景
* 該当シートがない場合はエラーメッセージを表示し、UserにOKを押させるするようにしていましたが、処理が止まるわけではなく、その後も続きます。
* 定義ファイル側でシート名を意図した名前に編集前に処理実行した場合、すべてのExcelが該当シートなしになり、上記のメッセージボックスを毎回幼いといけない事態になっていました。
## 目的
該当シートなしのExcel名のリストがゼロではない場合にその一覧を.csvファイルで出力する機能を追加する
